### PR TITLE
Update docker environment

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -56,7 +56,6 @@ services:
       TOB_CONNECTION_NAME: ${TOB_CONNECTION_NAME}
       WEBHOOK_PORT: ${WEBHOOK_PORT}
     networks:
-#local      - orgbook
       - myorg
     ports:
       - ${WEBHOOK_PORT}:${WEBHOOK_PORT}
@@ -87,7 +86,6 @@ services:
       - AGENT_ADMIN_PORT=${AGENT_ADMIN_PORT}
       - AGENT_NAME=${AGENT_NAME}
     networks:
-#local      - orgbook
       - myorg
     ports:
       - ${AGENT_HTTP_IN_PORT}:${AGENT_HTTP_IN_PORT}
@@ -135,7 +133,6 @@ services:
       - POSTGRESQL_DATABASE=${POSTGRESQL_DATABASE}
       - POSTGRESQL_ADMIN_PASSWORD=${POSTGRESQL_ADMIN_PASSWORD}
     networks:
-#local      - orgbook
       - myorg
     ports:
       - 5435:5432
@@ -202,6 +199,3 @@ volumes:
 
 networks:
   myorg:
-#local  orgbook:
-#local    external:
-#local      name: tob_tob

--- a/docker/manage
+++ b/docker/manage
@@ -94,7 +94,7 @@ configureEnvironment () {
   export POSTGRESQL_WALLET_PORT="5432"
   export POSTGRESQL_ADMIN_USER="postgres"
   export POSTGRESQL_ADMIN_PASSWORD="mysecretpassword"
-  export WALLET_SEED_VONX="myorg_issuer_0000000000000000001"
+  export WALLET_SEED_VONX=${WALLET_SEED_VONX:-"myorg_issuer_0000000000000000001"}
 
   # myorg-pipeline
   export COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-"vonx"}
@@ -104,7 +104,7 @@ configureEnvironment () {
   export VONX_API_URL=http://myorg-controller:${WEBHOOK_PORT}
 
   # myorg-controller
-  export TOB_AGENT_ADMIN_URL=${TOB_AGENT_ADMIN_URL:-http://tob-agent:${TOB_AGENT_ADMIN_PORT}} 
+  export TOB_AGENT_ADMIN_URL=${TOB_AGENT_ADMIN_URL:-http://${DOCKERHOST}:${TOB_AGENT_ADMIN_PORT}} 
   export TOB_CONNECTION_NAME=${TOB_CONNECTION_NAME:-tob-agent} 
 
   # myorg data source (directory)

--- a/init.sh
+++ b/init.sh
@@ -52,7 +52,6 @@ select example in "1" "2" "3"; do
             __TOBAPPURL=http://localhost:8080
 
             # Adjustments to files for local execution
-            sed -i.bak "s/#local//g" docker/docker-compose.yml
             sed -i.bak "s/ INDY_GENESIS_URL/ #INDY_GENESIS_URL/" issuer_controller/config/settings.yml
             # sed -i.bak "s/ AUTO_REGISTER_DID/ #AUTO_REGISTER_DID/" issuer_controller/config/settings.yml
             find docker issuer_controller -name "*.bak" -type f|xargs rm -f


### PR DESCRIPTION
- Change tob-agent URL to remove need for including the local docker network for TOB.
  - Update `init` script to match.
- Allow additional variables to be overridden.

Signed-off-by: Wade Barnes <wade.barnes@shaw.ca>