### PR TITLE
Working

### DIFF
--- a/issuer_pipeline/docker/mara-app/Dockerfile
+++ b/issuer_pipeline/docker/mara-app/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update -y \
 #   - The history issues with the OpenShift cron jobs are avoided.
 # --------------------------------------------------------------------------------------------------------
 ARG GOCROND_VERSION=0.6.1
-RUN curl https://github.com/$SOURCE_REPO/go-crond/releases/download/$GOCROND_VERSION/go-crond-64-linux -s -o /usr/local/bin/go-crond
+RUN curl https://github.com/$SOURCE_REPO/go-crond/releases/download/$GOCROND_VERSION/go-crond-64-linux -s -L -o /usr/local/bin/go-crond
 RUN chmod ug+x /usr/local/bin/go-crond
 # ========================================================================================================
 

--- a/issuer_pipeline/docker/mara-app/Dockerfile
+++ b/issuer_pipeline/docker/mara-app/Dockerfile
@@ -20,7 +20,8 @@ RUN apt-get update -y \
                 python$python_version-dev \
                 python$python_version-venv \
                 python-psycopg2 \
-                libpq-dev
+                libpq-dev \
+                curl
 
 # ========================================================================================================
 # Install go-crond (https://github.com/webdevops/go-crond)
@@ -33,9 +34,8 @@ RUN apt-get update -y \
 #   - The history issues with the OpenShift cron jobs are avoided.
 # --------------------------------------------------------------------------------------------------------
 ARG GOCROND_VERSION=0.6.1
-ADD https://github.com/webdevops/go-crond/releases/download/$GOCROND_VERSION/go-crond-64-linux /usr/bin/
-RUN mv /usr/bin/go-crond-64-linux /usr/bin/go-crond \
-    && chmod ug+x /usr/bin/go-crond
+RUN curl https://github.com/$SOURCE_REPO/go-crond/releases/download/$GOCROND_VERSION/go-crond-64-linux -s -o /usr/local/bin/go-crond
+RUN chmod ug+x /usr/local/bin/go-crond
 # ========================================================================================================
 
 # mara-app section - this is specific to our use of mara

--- a/issuer_pipeline/requirements.txt.freeze
+++ b/issuer_pipeline/requirements.txt.freeze
@@ -25,7 +25,7 @@ Mako==1.0.7
 -e git+https://github.com/mara/mara-app.git@66ba874d50fd30910ecf38f8c313c3a9f7e6624a#egg=mara_app
 -e git+https://github.com/mara/mara-db.git@4b496a8f82b780753c698cee70fe5619779d3906#egg=mara_db
 -e git+https://github.com/mara/mara-page.git@b1c32141080a322c9d8a7613ae1dc070479f762d#egg=mara_page
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 more-itertools==4.1.0
 multimethod==0.7.1
 oauth2client==4.1.2


### PR DESCRIPTION
To build errors corrected to latest docker desktop, win 10.

* A docker ADD changed to a RUN curl into a local bin (/usr/local/bin/) as per new best practices
* Frozen version of MarkupSafe (1.0) no-longer compatible with latest setuptools, MarkupSafe 1.1.1 is

