### PR TITLE
Update von-image version, add required build tools.

### DIFF
--- a/issuer_controller/Dockerfile
+++ b/issuer_controller/Dockerfile
@@ -1,10 +1,15 @@
-FROM bcgovimages/von-image:py36-1.11-1
+FROM bcgovimages/von-image:py36-1.15-0
 
 WORKDIR $HOME
 
 # `ADD --chown=` is not available in OpenShift yet.
 # ADD --chown=indy:indy . $HOME
 ADD . $HOME
+
+USER root
+RUN apt-get update && apt-get install -y build-essential
+
+RUN pip3 install --upgrade pip setuptools wheel
 
 RUN pip3 install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
Updates code to use latest `von-image` and adds build tools required by some python packages (`gevent` so far).