### PR TITLE
Support OIDC providers that do not include the algorithm in the JWK document

### DIFF
--- a/issuer_controller/src/authentication.py
+++ b/issuer_controller/src/authentication.py
@@ -53,7 +53,10 @@ def validate_token(*args, **kwargs):
                 for jwk in oidc_jwks["keys"]:
                     if jwk["kid"] == kid:
                         public_key = jwk
-                        algorithms = [jwk["alg"]]
+                        if "alg" in jwk:
+                            algorithms = [jwk["alg"]]
+                        else:
+                            algorithms = ["RS256"]
                 jwt.decode(
                     token,
                     public_key,


### PR DESCRIPTION
Support OIDC providers that do not include the algorithm in the JWK document (e.g.: Azure AD).

The OIDC spec states that the `alg` attribute is optional, and will therefore not be available in all JWKS endpoints. Using the default `RS256` algorithm if not explicitly available seems like the best fall-back option that does not involve requiring extra validation steps either in the client that is signing-in or in the controller, and should work in most scenarios.

Signed-off-by: Emiliano Suñé <emiliano.sune@gmail.com>