### PR TITLE
Update git references.

### DIFF
--- a/issuer_controller/config/README.md
+++ b/issuer_controller/config/README.md
@@ -47,7 +47,7 @@ Added to services.yml:
         credential_title: ...
 ```
 
-These fields are described below, and [here](https://github.com/bcgov/aries-vcr/blob/master/docs/Schema-changes.md).
+These fields are described below, and [here](https://github.com/bcgov/aries-vcr/blob/main/docs/Schema-changes.md).
 
 ## File: [schemas.yml](schemas.yml)
 


### PR DESCRIPTION
- The default branch of https://github.com/bcgov/aries-vcr.git has been renamed to `main`.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>