### PR TITLE
Add support for V20 credential exchange

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -160,6 +160,7 @@ services:
     environment:
       - WEBHOOK_PORT=${WEBHOOK_PORT}
       - VONX_API_URL=${VONX_API_URL:-http://myorg-controller:8000}
+      - ISSUE_CRED_VERSION=${ISSUE_CRED_VERSION:-V10}
       # [pipeline data source (directory)]
       #- EAO_MDB_DB_HOST=${EAO_MDB_DB_HOST:-mongo}
       #- EAO_MDB_DB_PORT=${EAO_MDB_DB_PORT:-27017}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -160,7 +160,7 @@ services:
     environment:
       - WEBHOOK_PORT=${WEBHOOK_PORT}
       - VONX_API_URL=${VONX_API_URL:-http://myorg-controller:8000}
-      - ISSUE_CRED_VERSION=${ISSUE_CRED_VERSION:-V10}
+      - ISSUE_CRED_VERSION=${ISSUE_CRED_VERSION:-V20}
       # [pipeline data source (directory)]
       #- EAO_MDB_DB_HOST=${EAO_MDB_DB_HOST:-mongo}
       #- EAO_MDB_DB_PORT=${EAO_MDB_DB_PORT:-27017}

--- a/docker/manage
+++ b/docker/manage
@@ -145,6 +145,7 @@ configureEnvironment () {
   export APPLICATION_URL=${APPLICATION_URL-http://localhost:${WEB_HTTP_PORT:-5000}}
   export ENDPOINT_URL=http://${ENDPOINT_HOST-$DOCKERHOST:${WEB_HTTP_PORT:-5001}}
   export VONX_API_URL=http://myorg-controller:${WEBHOOK_PORT}
+  export ISSUE_CRED_VERSION=${ISSUE_CRED_VERSION:-"V10"}
 
   # myorg-controller
   # specify this as anything other than "true" to force manual connection to the TOB agent

--- a/docker/manage
+++ b/docker/manage
@@ -145,7 +145,7 @@ configureEnvironment () {
   export APPLICATION_URL=${APPLICATION_URL-http://localhost:${WEB_HTTP_PORT:-5000}}
   export ENDPOINT_URL=http://${ENDPOINT_HOST-$DOCKERHOST:${WEB_HTTP_PORT:-5001}}
   export VONX_API_URL=http://myorg-controller:${WEBHOOK_PORT}
-  export ISSUE_CRED_VERSION=${ISSUE_CRED_VERSION:-"V10"}
+  export ISSUE_CRED_VERSION=${ISSUE_CRED_VERSION:-"V20"}
 
   # myorg-controller
   # specify this as anything other than "true" to force manual connection to the TOB agent


### PR DESCRIPTION
Add support for v20 credential exchange. Specify the protocol to use using the env var ISSUE_CRED_VERSION - values are V10 and V20 (default is V20 if not specified).

This can be set for the container, or specifically for the cred submitter job as follows:

```
ISSUE_CRED_VERSION=V20 ./run-step.sh von_pipeline/submit-creds.py
```
